### PR TITLE
Fix auto.sh script

### DIFF
--- a/auto.sh
+++ b/auto.sh
@@ -32,15 +32,15 @@ read -p "[#] Enter Selected Number: " marks
 echo 
 if [ $marks = 1 ]
 then
-    instagram --username $usrnm --password-list $HOME/Instabruteforce/pass1.txt 
+    instagram-py --username $usrnm --password-list $HOME/Instabruteforce/pass1.txt 
  
 elif [ $marks = 2 ]
 then
-    instagram --username $usrnm --password-list $HOME/Instabruteforce/pass2.txt
+    instagram-py --username $usrnm --password-list $HOME/Instabruteforce/pass2.txt
  
 elif [ $marks = 3 ]
 then
-    instagram --username $usrnm --password-list $HOME/Instabruteforce/pass3.txt
+    instagram-py --username $usrnm --password-list $HOME/Instabruteforce/pass3.txt
 else
 echo
 echo -e  "$ylo >>> exiting........! Bye Bye :) <<<$rset"


### PR DESCRIPTION
## Description
There was a small type in the ```auto.sh``` script where ```instagram``` command was being used for the brute-force attack instead of the expected ```instagram-py``` as seen in the ```manual.sh``` script which seems to work fine. This PR updates all the instances of the wrong command to the expected command to get the desired results for the end user.

Fixes issue #2 

